### PR TITLE
CI: Queue up doc pushes

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,6 +8,12 @@ on:
       - 'mkdocs.yaml'
       - '.github/workflows/deploy-docs.yml'
 
+
+# Prevent concurrent runs that could conflict when pushing to gh-pages
+concurrency:
+  group: build-docs-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 


### PR DESCRIPTION
    This action fails if more than 1 is running at the same time (which
    happens if you merge multiple PRs in quick succession). Fix is by
    disabling concurrency, so they just queue up.